### PR TITLE
fix(cron): accept Authorization Bearer header for CRON_SECRET auth

### DIFF
--- a/src/lib/cronAuth.js
+++ b/src/lib/cronAuth.js
@@ -29,8 +29,11 @@ export function verifyCronAuth(request) {
 
   const cronSecret = process.env.CRON_SECRET;
   const providedSecret = request.headers.get('x-cron-secret');
+  const authHeader = request.headers.get('authorization') || '';
+  const bearerSecret = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+  const secretValid = cronSecret && (providedSecret === cronSecret || bearerSecret === cronSecret);
 
-  if (cronSecret && !manualTokenValid && providedSecret !== cronSecret) {
+  if (cronSecret && !manualTokenValid && !secretValid) {
     return { authorized: false, dryRun: false, force: false, status: 401 };
   }
 


### PR DESCRIPTION
## Summary

- Vercel native cron sends the secret as `Authorization: Bearer <CRON_SECRET>`, but [`verifyCronAuth`](src/lib/cronAuth.js) only checked `x-cron-secret`
- Once `CRON_SECRET` was set in Vercel production env (earlier today), every cron invocation returned 401 — `demote-today-tasks`, `demote-week-tasks`, `daily-task-email`, and `office365-sync` all silently failed auth and never ran
- This patch accepts both header conventions (existing `x-cron-secret` + new `Authorization: Bearer`) so native Vercel crons and manual invocations both work

## Why

Three user-reported bugs (stuck Today tasks, no digest emails, weekly planning not clearing stale tasks) converged on this single auth-layer failure. Root-cause analysis is in [docs/superpowers/specs/2026-04-20-task-lifecycle-bugs-discovery.md](docs/superpowers/specs/2026-04-20-task-lifecycle-bugs-discovery.md).

## Test plan

- [ ] Merge triggers Vercel production deploy
- [ ] Check Vercel Functions → Crons invocation history for `/api/cron/demote-today-tasks` after the next 19:55 UTC window — should return 200 instead of 401
- [ ] Confirm new row appears in `cron_runs` table with `operation='demote_today', status='success'`
- [ ] Confirm digest email arrives tomorrow at 07:00 UTC (08:00 BST)

## Complexity score
XS — 4-line change to one file, no schema changes, no breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)