### PR TITLE
fix(tasks): refetch task lists on every mutation, not only after planning

### DIFF
--- a/src/components/calendar/CalendarView.jsx
+++ b/src/components/calendar/CalendarView.jsx
@@ -60,11 +60,15 @@ export default function CalendarView() {
     fetchTasks();
   }, [fetchTasks]);
 
-  // Refetch when planning is completed
+  // Refetch when planning completes or any task mutates
   useEffect(() => {
-    const handlePlanningComplete = () => { fetchTasks(); };
-    window.addEventListener('planning-complete', handlePlanningComplete);
-    return () => window.removeEventListener('planning-complete', handlePlanningComplete);
+    const handle = () => { fetchTasks(); };
+    window.addEventListener('planning-complete', handle);
+    window.addEventListener('tasks-changed', handle);
+    return () => {
+      window.removeEventListener('planning-complete', handle);
+      window.removeEventListener('tasks-changed', handle);
+    };
   }, [fetchTasks]);
 
   // Month navigation

--- a/src/components/plan/PlanBoard.jsx
+++ b/src/components/plan/PlanBoard.jsx
@@ -268,11 +268,15 @@ export default function PlanBoard() {
     loadAllColumns();
   }, [loadAllColumns]);
 
-  // Refetch when planning is completed
+  // Refetch when planning completes or any task mutates
   useEffect(() => {
-    const handlePlanningComplete = () => { loadAllColumns(); };
-    window.addEventListener('planning-complete', handlePlanningComplete);
-    return () => window.removeEventListener('planning-complete', handlePlanningComplete);
+    const handle = () => { loadAllColumns(); };
+    window.addEventListener('planning-complete', handle);
+    window.addEventListener('tasks-changed', handle);
+    return () => {
+      window.removeEventListener('planning-complete', handle);
+      window.removeEventListener('tasks-changed', handle);
+    };
   }, [loadAllColumns]);
 
   // ---------------------------------------------------------------------------

--- a/src/components/today/TodayView.jsx
+++ b/src/components/today/TodayView.jsx
@@ -169,11 +169,15 @@ export default function TodayView() {
     loadData();
   }, [loadData]);
 
-  // Refetch when planning is completed
+  // Refetch when planning completes or any task mutates
   useEffect(() => {
-    const handlePlanningComplete = () => { loadData(); };
-    window.addEventListener('planning-complete', handlePlanningComplete);
-    return () => window.removeEventListener('planning-complete', handlePlanningComplete);
+    const handle = () => { loadData(); };
+    window.addEventListener('planning-complete', handle);
+    window.addEventListener('tasks-changed', handle);
+    return () => {
+      window.removeEventListener('planning-complete', handle);
+      window.removeEventListener('tasks-changed', handle);
+    };
   }, [loadData]);
 
   // ---------------------------------------------------------------------------

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -3,6 +3,12 @@
 
 import { dedupedFetch, clearCache, clearCacheByPrefix } from './requestCache';
 
+function dispatchTasksChanged() {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent('tasks-changed'));
+  }
+}
+
 class APIClient {
   async fetchWithAuth(url, options = {}) {
     const response = await fetch(url, {
@@ -163,6 +169,7 @@ class APIClient {
       method: 'POST',
       body: JSON.stringify(payload),
     });
+    dispatchTasksChanged();
     return result?.data ?? result;
   }
 
@@ -181,13 +188,16 @@ class APIClient {
       method: 'PATCH',
       body: JSON.stringify({ id: taskId, ...cleanUpdates }),
     });
+    dispatchTasksChanged();
     return result?.data ?? result;
   }
 
   async deleteTask(taskId) {
-    return this.fetchWithAuth(`/api/tasks/${taskId}`, {
+    const result = await this.fetchWithAuth(`/api/tasks/${taskId}`, {
       method: 'DELETE',
     });
+    dispatchTasksChanged();
+    return result;
   }
 
   // Update sort order for a list of tasks


### PR DESCRIPTION
## What changed

`apiClient.createTask` / `updateTask` / `deleteTask` now dispatch a `tasks-changed` CustomEvent on `window` after the API call succeeds. `TodayView`, `CalendarView`, and `PlanBoard` now listen for `tasks-changed` in addition to the existing `planning-complete` event.

## Why

QuickCapture (the bottom `+` button) was silently broken: it successfully wrote the task to the DB, showed a success flash, then left every task list stale until a hard reload. Root cause was an asymmetric mutation→refresh contract — `planning-complete` was dispatched only from `usePlanningPrompt.js`, so any task mutation outside the Planning Modal flow left views stale.

Full root-cause analysis in [docs/superpowers/specs/2026-04-20-task-lifecycle-bugs-discovery.md](docs/superpowers/specs/2026-04-20-task-lifecycle-bugs-discovery.md) (Bug #4).

## Testing done

- [x] Manual: `npm run lint` — clean
- [x] Manual: `npm run build` — clean
- [ ] Manual smoke test after deploy: open Today view, tap `+`, press Shift+Enter on "test task". Task should appear in Today > Good to Do without reloading. Press Enter on another "test backlog task"; switch to Plan Board; new task should appear in the Backlog column without reloading.

## Complexity score

S — 4 files, additive changes only, no schema touched, no breaking changes.

## Breaking changes

None. `planning-complete` listeners still in place; the new `tasks-changed` listener is additive.

## Migration risk

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)